### PR TITLE
ENTESB-10551: Fixed the cxf-xjc-utils build on my machine

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,14 @@
             <releases>
                 <enabled>false</enabled>
             </releases>
-        </repository> 
+        </repository>
+        <repository>
+            <id>redhat.earlyaccess</id>
+            <url>https://maven.repository.redhat.com/earlyaccess</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
     </repositories>
     <dependencyManagement>
         <dependencies>


### PR DESCRIPTION
My understanding of current team practice is that we explicit needed repositories in pom files. And I needed this one to build on my machine.